### PR TITLE
Add browser MIDI generator with playback and download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# React + Vite
+# Trackify
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Generate simple MIDI sketches from the browser. Enter a genre, time signature, tempo, and style to build a song with drums, bass, keys, and rhythm guitar. The song contains intro, verse, chorus, bridge, and outro sections.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Install dependencies: `npm install`
+- Start the dev server: `npm run dev`
+- Lint the code: `npm run lint`
 
-## Expanding the ESLint configuration
+## Usage
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+Use the form to provide parameters. After generation you can play the song in the browser and download the resulting MIDI file.

--- a/index.html
+++ b/index.html
@@ -2,9 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React</title>
+    <title>Trackify</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "trackify",
       "version": "0.0.0",
       "dependencies": {
+        "@tonejs/midi": "^2.0.28",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "tone": "^15.1.22"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -21,6 +23,15 @@
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.3.0",
         "vite": "^7.1.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1198,6 +1209,16 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tonejs/midi": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/@tonejs/midi/-/midi-2.0.28.tgz",
+      "integrity": "sha512-RII6YpInPsOZ5t3Si/20QKpNqB1lZ2OCFJSOzJxz38YdY/3zqDr3uaml4JuCWkdixuPqP1/TBnXzhQ39csyoVg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^3.0.0",
+        "midi-file": "^1.2.2"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1311,6 +1332,25 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/array-flatten": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
+    },
+    "node_modules/automation-events": {
+      "version": "7.1.12",
+      "resolved": "https://registry.npmjs.org/automation-events/-/automation-events-7.1.12.tgz",
+      "integrity": "sha512-JDdPQoV58WPm15/L3ABtIEiqyxLoW+yTYIEqYtrKZ7VizLSRXhMKRZbQ8CYc2mFq/lMRKUvqOj0OcT3zANFiXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1953,6 +1993,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/midi-file": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/midi-file/-/midi-file-1.2.4.tgz",
+      "integrity": "sha512-B5SnBC6i2bwJIXTY9MElIydJwAmnKx+r5eJ1jknTLetzLflEl0GWveuBB6ACrQpecSRkOB6fhTx1PwXk2BVxnA==",
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2261,6 +2307,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/standardized-audio-context": {
+      "version": "25.3.77",
+      "resolved": "https://registry.npmjs.org/standardized-audio-context/-/standardized-audio-context-25.3.77.tgz",
+      "integrity": "sha512-Ki9zNz6pKcC5Pi+QPjPyVsD9GwJIJWgryji0XL9cAJXMGyn+dPOf6Qik1AHei0+UNVcc4BOCa0hWLBzlwqsW/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.6",
+        "automation-events": "^7.0.9",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -2303,6 +2360,22 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tone": {
+      "version": "15.1.22",
+      "resolved": "https://registry.npmjs.org/tone/-/tone-15.1.22.tgz",
+      "integrity": "sha512-TCScAGD4sLsama5DjvTUXlLDXSqPealhL64nsdV1hhr6frPWve0DeSo63AKnSJwgfg55fhvxj0iPPRwPN5o0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "standardized-audio-context": "^25.3.70",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tonejs/midi": "^2.0.28",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "tone": "^15.1.22"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,25 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.App {
   text-align: center;
+  padding: 2rem;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 300px;
+  margin: 1rem auto;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+.actions {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,70 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { generateSong } from './midiGenerator'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [form, setForm] = useState({
+    genre: '',
+    timeSignature: '4/4',
+    tempo: 120,
+    style: '',
+  })
+  const [midiUrl, setMidiUrl] = useState(null)
+  const [startPlayback, setStartPlayback] = useState(null)
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value })
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    const { url, start } = generateSong(form)
+    setMidiUrl(url)
+    setStartPlayback(() => start)
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="App">
+      <h1>Trackify</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          Genre
+          <input name="genre" value={form.genre} onChange={handleChange} />
+        </label>
+        <label>
+          Time Signature
+          <input
+            name="timeSignature"
+            value={form.timeSignature}
+            onChange={handleChange}
+          />
+        </label>
+        <label>
+          Tempo
+          <input
+            type="number"
+            name="tempo"
+            value={form.tempo}
+            onChange={handleChange}
+          />
+        </label>
+        <label>
+          Style
+          <input name="style" value={form.style} onChange={handleChange} />
+        </label>
+        <button type="submit">Create Song</button>
+      </form>
+      {startPlayback && (
+        <div className="actions">
+          <button onClick={startPlayback}>Play</button>
+          {midiUrl && (
+            <a href={midiUrl} download="song.mid">
+              Download MIDI
+            </a>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/src/midiGenerator.js
+++ b/src/midiGenerator.js
@@ -1,0 +1,117 @@
+import * as Tone from 'tone'
+import { Midi } from '@tonejs/midi'
+
+export function generateSong({ genre, timeSignature, tempo, style }) {
+  Tone.Transport.stop()
+  Tone.Transport.cancel()
+
+  const [beatsPerMeasure, beatUnit] = timeSignature.split('/').map(Number)
+  const beatDuration = 60 / tempo
+
+  Tone.Transport.bpm.value = tempo
+  Tone.Transport.timeSignature = [beatsPerMeasure, beatUnit]
+
+  const midi = new Midi()
+  midi.name = `${genre} ${style}`
+  midi.header.setTempo(tempo)
+  midi.header.timeSignatures.push({
+    ticks: 0,
+    timeSignature: [beatsPerMeasure, beatUnit],
+  })
+
+  const synths = {
+    drums: new Tone.PolySynth(Tone.Synth).toDestination(),
+    bass: new Tone.PolySynth(Tone.Synth).toDestination(),
+    keys: new Tone.PolySynth(Tone.Synth).toDestination(),
+    guitar: new Tone.PolySynth(Tone.Synth).toDestination(),
+  }
+
+  const parts = {}
+  const events = {
+    drums: [],
+    bass: [],
+    keys: [],
+    guitar: [],
+  }
+
+  const sections = ['intro', 'verse', 'chorus', 'bridge', 'outro']
+  const measuresPerSection = 2
+  let currentBeat = 0
+
+  sections.forEach(() => {
+    for (let m = 0; m < measuresPerSection; m++) {
+      const measureStart = currentBeat + m * beatsPerMeasure
+
+      for (let b = 0; b < beatsPerMeasure; b++) {
+        const time = measureStart + b
+        events.drums.push({ time, note: 'G3', duration: 1 })
+
+        if (b === 0 || b === Math.floor(beatsPerMeasure / 2)) {
+          events.drums.push({ time, note: 'C3', duration: 1 })
+        }
+        if (b === Math.floor(beatsPerMeasure / 2)) {
+          events.drums.push({ time, note: 'D3', duration: 1 })
+        }
+      }
+
+      events.bass.push({
+        time: measureStart,
+        note: 'C2',
+        duration: beatsPerMeasure,
+      })
+
+      ;['C4', 'E4', 'G4'].forEach((n) => {
+        events.keys.push({
+          time: measureStart,
+          note: n,
+          duration: beatsPerMeasure,
+        })
+      })
+
+      for (let b = 0; b < beatsPerMeasure; b += 2) {
+        ;['C3', 'E3', 'G3'].forEach((n) => {
+          events.guitar.push({
+            time: measureStart + b,
+            note: n,
+            duration: 1,
+          })
+        })
+      }
+    }
+    currentBeat += measuresPerSection * beatsPerMeasure
+  })
+
+  Object.keys(events).forEach((name) => {
+    const evs = events[name]
+    parts[name] = new Tone.Part(
+      (time, value) => {
+        synths[name].triggerAttackRelease(
+          value.note,
+          value.duration * beatDuration,
+          time,
+        )
+      },
+      evs.map((ev) => [ev.time * beatDuration, ev]),
+    )
+    parts[name].start(0)
+
+    const track = midi.addTrack()
+    evs.forEach((ev) => {
+      track.addNote({
+        midi: Tone.Frequency(ev.note).toMidi(),
+        time: ev.time * beatDuration,
+        duration: ev.duration * beatDuration,
+      })
+    })
+  })
+
+  const start = async () => {
+    await Tone.start()
+    Tone.Transport.start()
+  }
+
+  const blob = new Blob([midi.toArray()], { type: 'audio/midi' })
+  const url = URL.createObjectURL(blob)
+
+  return { url, start }
+}


### PR DESCRIPTION
## Summary
- replace default Vite template with Trackify form
- generate drums, bass, keys and guitar MIDI for five song sections
- play generated song and offer MIDI file download in browser

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a12c0b05608327be31a6d3806d558e