### PR TITLE
Display chord progressions for each song section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ function App() {
   })
   const [midiUrl, setMidiUrl] = useState(null)
   const [startPlayback, setStartPlayback] = useState(null)
+  const [chordProgressions, setChordProgressions] = useState(null)
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value })
@@ -19,9 +20,10 @@ function App() {
 
   const handleSubmit = (e) => {
     e.preventDefault()
-    const { url, start } = generateSong(form)
+    const { url, start, chordProgressions: chords } = generateSong(form)
     setMidiUrl(url)
     setStartPlayback(() => start)
+    setChordProgressions(chords)
   }
 
   return (
@@ -81,6 +83,16 @@ function App() {
               Download MIDI
             </a>
           )}
+        </div>
+      )}
+      {chordProgressions && (
+        <div className="chords">
+          <h2>Chord Progressions</h2>
+          {Object.entries(chordProgressions).map(([section, chords]) => (
+            <p key={section}>
+              <strong>{section}:</strong> {chords.join(' - ')}
+            </p>
+          ))}
         </div>
       )}
     </div>

--- a/src/midiGenerator.js
+++ b/src/midiGenerator.js
@@ -65,11 +65,16 @@ export function generateSong({ genre, key, timeSignature, tempo, style }) {
   const progression = genreProgressions[genre] || [0, 5, 7]
   const intervals = chordIntervals[genre] || [0, 4, 7]
 
-  sections.forEach(() => {
+  const chordProgressions = {}
+
+  sections.forEach((section) => {
+    chordProgressions[section] = []
     for (let m = 0; m < measuresPerSection; m++) {
       const measureStart = currentBeat + m * beatsPerMeasure
       const rootSemitone =
         progression[Math.floor(Math.random() * progression.length)]
+      const chordName = noteInKey(rootSemitone, 3).replace(/\d/g, '')
+      chordProgressions[section].push(chordName)
       const chordNotes = intervals.map((i) => noteInKey(rootSemitone + i, 4))
       const chordNotesGtr = intervals.map((i) => noteInKey(rootSemitone + i, 3))
 
@@ -142,5 +147,5 @@ export function generateSong({ genre, key, timeSignature, tempo, style }) {
   const blob = new Blob([midi.toArray()], { type: 'audio/midi' })
   const url = URL.createObjectURL(blob)
 
-  return { url, start }
+  return { url, start, chordProgressions }
 }


### PR DESCRIPTION
## Summary
- generate chord progressions for intro, verse, chorus, bridge, and outro
- return chord progressions from song generator and show them in UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1cb380074832784c0ec5ce20296b7